### PR TITLE
use a url safe encoding for the key

### DIFF
--- a/lib/proca_web/resolvers/contact.ex
+++ b/lib/proca_web/resolvers/contact.ex
@@ -54,7 +54,7 @@ defmodule ProcaWeb.Resolvers.Contact do
       action_page ->
         case create_signature(action_page, signature) do
           {:ok, %Signature{id: _signature_id, fingerprint: fpr}} ->
-            {:ok, Base.encode64(fpr)}
+            {:ok, Base.url_encode64(fpr)}
           {:error, %Ecto.Changeset{} = changeset} ->
             {:error, Helper.format_errors(changeset)}
           _ ->


### PR DESCRIPTION
...so we can use it for the utm_source on the share action for instance.

Alternative: we use a url_encode64(uuid v4) as an extra "key" (like I do on the client side when I generate an action without contacts)